### PR TITLE
Add monthly summary metrics with persistence and reports

### DIFF
--- a/src/ViewModels/TopMonthViewModel.cs
+++ b/src/ViewModels/TopMonthViewModel.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Windows.Input;
+
+namespace CalendarApp.ViewModels
+{
+    public class TopMonthViewModel : INotifyPropertyChanged
+    {
+        public ObservableCollection<MonthSummary> Summaries { get; } = new();
+        public ObservableCollection<ReportSummary> QuarterlyReport { get; } = new();
+        private ReportSummary yearlyReport = new ReportSummary();
+        public ReportSummary YearlyReport
+        {
+            get => yearlyReport;
+            private set { yearlyReport = value; OnPropertyChanged(nameof(YearlyReport)); }
+        }
+
+        public ICommand SaveCommand { get; }
+        public ICommand LoadCommand { get; }
+
+        public TopMonthViewModel()
+        {
+            for (int m = 1; m <= 12; m++)
+            {
+                var summary = new MonthSummary { Month = m };
+                summary.PropertyChanged += (_, __) => UpdateReports();
+                Summaries.Add(summary);
+            }
+
+            SaveCommand = new RelayCommand(_ => { SaveData(); UpdateReports(); });
+            LoadCommand = new RelayCommand(_ => { LoadData(); UpdateReports(); });
+
+            LoadData();
+            UpdateReports();
+        }
+
+        private string DataFilePath => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "topmonth_metrics.json");
+
+        private void SaveData()
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(DataFilePath, JsonSerializer.Serialize(Summaries, options));
+        }
+
+        private void LoadData()
+        {
+            if (File.Exists(DataFilePath))
+            {
+                var json = File.ReadAllText(DataFilePath);
+                var items = JsonSerializer.Deserialize<ObservableCollection<MonthSummary>>(json);
+                if (items != null && items.Count == 12)
+                {
+                    Summaries.Clear();
+                    foreach (var item in items)
+                    {
+                        item.PropertyChanged += (_, __) => UpdateReports();
+                        Summaries.Add(item);
+                    }
+                }
+            }
+        }
+
+        private void UpdateReports()
+        {
+            QuarterlyReport.Clear();
+            foreach (var grp in Summaries.GroupBy(s => (s.Month - 1) / 3 + 1))
+            {
+                QuarterlyReport.Add(new ReportSummary
+                {
+                    Period = $"Q{grp.Key}",
+                    Profit = grp.Sum(x => x.Profit),
+                    Views = grp.Sum(x => x.Views)
+                });
+            }
+
+            YearlyReport = new ReportSummary
+            {
+                Period = "Year",
+                Profit = Summaries.Sum(x => x.Profit),
+                Views = Summaries.Sum(x => x.Views)
+            };
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+        public class MonthSummary : INotifyPropertyChanged
+        {
+            public int Month { get; set; }
+
+            private decimal profit;
+            public decimal Profit
+            {
+                get => profit;
+                set { profit = value; OnPropertyChanged(nameof(Profit)); }
+            }
+
+            private int views;
+            public int Views
+            {
+                get => views;
+                set { views = value; OnPropertyChanged(nameof(Views)); }
+            }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        public class ReportSummary
+        {
+            public string Period { get; set; }
+            public decimal Profit { get; set; }
+            public int Views { get; set; }
+        }
+
+        private class RelayCommand : ICommand
+        {
+            private readonly Action<object> execute;
+            public RelayCommand(Action<object> execute) => this.execute = execute;
+            public bool CanExecute(object parameter) => true;
+            public void Execute(object parameter) => execute(parameter);
+            public event EventHandler CanExecuteChanged { add { } remove { } }
+        }
+    }
+}

--- a/src/Views/TopMonthPanel.xaml
+++ b/src/Views/TopMonthPanel.xaml
@@ -1,0 +1,42 @@
+<UserControl x:Class="CalendarApp.Views.TopMonthPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <Button Content="Load" Command="{Binding LoadCommand}" Margin="0,0,10,0"/>
+            <Button Content="Save" Command="{Binding SaveCommand}"/>
+        </StackPanel>
+
+        <DataGrid Grid.Row="1" ItemsSource="{Binding Summaries}" AutoGenerateColumns="False" CanUserAddRows="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Month" Binding="{Binding Month}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Profit" Binding="{Binding Profit, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTextColumn Header="Views" Binding="{Binding Views, UpdateSourceTrigger=PropertyChanged}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <DataGrid Grid.Row="2" ItemsSource="{Binding QuarterlyReport}" AutoGenerateColumns="False" Margin="0,10,0,0" CanUserAddRows="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Period" Binding="{Binding Period}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Profit" Binding="{Binding Profit}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Views" Binding="{Binding Views}" IsReadOnly="True"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,10,0,0">
+            <TextBlock Text="Year" FontWeight="Bold" Margin="0,0,10,0"/>
+            <TextBlock Text="{Binding YearlyReport.Profit, StringFormat=Profit\: {0:F2}}" Margin="0,0,10,0"/>
+            <TextBlock Text="{Binding YearlyReport.Views, StringFormat=Views\: {0}}"/>
+        </StackPanel>
+    </Grid>
+</UserControl>


### PR DESCRIPTION
## Summary
- Add `TopMonthPanel` view that displays monthly metrics and aggregated quarterly and yearly summaries
- Implement `TopMonthViewModel` with JSON persistence and computation of quarterly/yearly reports

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adca7e33448332859989ddd3e5d175