### PR TITLE
Add post schedule panel with priority markers

### DIFF
--- a/src/ViewModels/PostScheduleViewModel.cs
+++ b/src/ViewModels/PostScheduleViewModel.cs
@@ -1,0 +1,21 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace CalendarApp.ViewModels
+{
+    public class PostScheduleViewModel : INotifyPropertyChanged
+    {
+        private readonly MainCalendarViewModel calendar;
+
+        public ObservableCollection<MainCalendarViewModel.DayTask> Days => calendar.Days;
+        public ObservableCollection<MainCalendarViewModel.Priority> Priorities => calendar.Priorities;
+
+        public PostScheduleViewModel(MainCalendarViewModel calendar)
+        {
+            this.calendar = calendar;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/src/Views/PostSchedulePanel.xaml
+++ b/src/Views/PostSchedulePanel.xaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="CalendarApp.Views.PostSchedulePanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <ScrollViewer>
+        <ItemsControl ItemsSource="{Binding Days}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border BorderBrush="Gray" BorderThickness="1" Background="{Binding PriorityBrush}" Margin="2" Padding="4">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding Date, StringFormat=d}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Column="1" Text="{Binding Plan, UpdateSourceTrigger=PropertyChanged}" Margin="5,0"/>
+                            <ComboBox Grid.Column="2" Width="100" ItemsSource="{Binding DataContext.Priorities, RelativeSource={RelativeSource AncestorType=UserControl}}" SelectedItem="{Binding Priority}" Margin="5,0"/>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </ScrollViewer>
+</UserControl>


### PR DESCRIPTION
## Summary
- Add PostSchedulePanel user control that lists daily releases with editable plans and priority selection.
- Implement PostScheduleViewModel to expose calendar days and priority options for the panel.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(cancelled due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68adcb78b2308332aefb415b3b764e7c