### PR TITLE
Add statistics panel with yearly metrics and charts

### DIFF
--- a/src/ViewModels/StatisticsViewModel.cs
+++ b/src/ViewModels/StatisticsViewModel.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows;
+
+namespace CalendarApp.ViewModels
+{
+    public class StatisticsViewModel : INotifyPropertyChanged
+    {
+        public ObservableCollection<YearlyMetric> Metrics { get; } = new();
+        public ObservableCollection<SoftwareCost> SoftwareCosts { get; } = new();
+        public ObservableCollection<ChartSeries> Charts { get; } = new();
+        public ObservableCollection<string> AvailableColors { get; } = new()
+        {
+            "Red", "Green", "Blue", "Orange", "Purple", "Black"
+        };
+
+        public StatisticsViewModel()
+        {
+            var currentYear = DateTime.Now.Year;
+            for (int y = currentYear - 4; y <= currentYear; y++)
+            {
+                Metrics.Add(new YearlyMetric { Year = y });
+            }
+
+            SoftwareCosts.Add(new SoftwareCost { Name = "Licenses" });
+            SoftwareCosts.Add(new SoftwareCost { Name = "Subscriptions" });
+
+            Charts.Add(new ChartSeries { Name = "Profit", LineColor = "Green" });
+            Charts.Add(new ChartSeries { Name = "Views", LineColor = "Blue" });
+            Charts.Add(new ChartSeries { Name = "Software Cost", LineColor = "Orange" });
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+        public class YearlyMetric : INotifyPropertyChanged
+        {
+            public int Year { get; set; }
+
+            private decimal profit;
+            public decimal Profit
+            {
+                get => profit;
+                set { profit = value; OnPropertyChanged(nameof(Profit)); }
+            }
+
+            private int views;
+            public int Views
+            {
+                get => views;
+                set { views = value; OnPropertyChanged(nameof(Views)); }
+            }
+
+            private decimal softwareCost;
+            public decimal SoftwareCost
+            {
+                get => softwareCost;
+                set { softwareCost = value; OnPropertyChanged(nameof(SoftwareCost)); }
+            }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        public class SoftwareCost : INotifyPropertyChanged
+        {
+            public string Name { get; set; }
+
+            private decimal cost;
+            public decimal Cost
+            {
+                get => cost;
+                set { cost = value; OnPropertyChanged(nameof(Cost)); }
+            }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        public class ChartSeries : INotifyPropertyChanged
+        {
+            public string Name { get; set; }
+            public ObservableCollection<Point> Points { get; } = new();
+
+            private string lineColor = "Blue";
+            public string LineColor
+            {
+                get => lineColor;
+                set { lineColor = value; OnPropertyChanged(nameof(LineColor)); }
+            }
+
+            private bool isVisible = true;
+            public bool IsVisible
+            {
+                get => isVisible;
+                set { isVisible = value; OnPropertyChanged(nameof(IsVisible)); }
+            }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/src/Views/StatisticsPanel.xaml
+++ b/src/Views/StatisticsPanel.xaml
@@ -1,0 +1,54 @@
+<UserControl x:Class="CalendarApp.Views.StatisticsPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+    </UserControl.Resources>
+    <ScrollViewer>
+        <StackPanel Margin="10">
+            <TextBlock Text="Yearly Metrics" FontWeight="Bold" FontSize="14" Margin="0,0,0,10"/>
+            <DataGrid ItemsSource="{Binding Metrics}" AutoGenerateColumns="False" CanUserAddRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Year" Binding="{Binding Year}" IsReadOnly="True"/>
+                    <DataGridTextColumn Header="Profit" Binding="{Binding Profit, UpdateSourceTrigger=PropertyChanged}"/>
+                    <DataGridTextColumn Header="Views" Binding="{Binding Views, UpdateSourceTrigger=PropertyChanged}"/>
+                    <DataGridTextColumn Header="Software Cost" Binding="{Binding SoftwareCost, UpdateSourceTrigger=PropertyChanged}"/>
+                </DataGrid.Columns>
+            </DataGrid>
+
+            <GroupBox Header="Затраты на софт" Margin="0,10,0,0">
+                <DataGrid ItemsSource="{Binding SoftwareCosts}" AutoGenerateColumns="False" CanUserAddRows="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Software" Binding="{Binding Name}" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost, UpdateSourceTrigger=PropertyChanged}"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </GroupBox>
+
+            <TextBlock Text="Charts" FontWeight="Bold" FontSize="14" Margin="0,10,0,10"/>
+            <ItemsControl ItemsSource="{Binding Charts}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Expander Header="{Binding Name}" IsExpanded="False" Margin="0,0,0,10">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                                    <CheckBox Content="Show" IsChecked="{Binding IsVisible}" Margin="0,0,10,0"/>
+                                    <TextBlock Text="Color:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <ComboBox Width="100" ItemsSource="{Binding DataContext.AvailableColors, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                              SelectedItem="{Binding LineColor}"/>
+                                </StackPanel>
+                                <Canvas Height="150" Margin="0,5,0,0">
+                                    <Polyline Points="{Binding Points}" Stroke="{Binding LineColor}" StrokeThickness="2"
+                                              Visibility="{Binding IsVisible, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                </Canvas>
+                            </StackPanel>
+                        </Expander>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>


### PR DESCRIPTION
## Summary
- Create `StatisticsViewModel` to manage yearly metrics, software costs, and configurable chart series
- Add `StatisticsPanel` view with tables and expandable line charts that support color selection and visibility filtering

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68add28235988332a29055f6cd3a8e68