### PR TITLE
Add settings panel with theme and priority controls

### DIFF
--- a/src/ViewModels/SettingsViewModel.cs
+++ b/src/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,140 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Media;
+using CalendarApp.Services;
+
+namespace CalendarApp.ViewModels
+{
+    public class SettingsViewModel : INotifyPropertyChanged
+    {
+        private readonly MainCalendarViewModel calendar;
+
+        public ObservableCollection<string> Themes { get; } = new() { "Light", "Dark" };
+        private string selectedTheme;
+        public string SelectedTheme
+        {
+            get => selectedTheme;
+            set
+            {
+                if (selectedTheme != value)
+                {
+                    selectedTheme = value;
+                    OnPropertyChanged(nameof(SelectedTheme));
+                }
+            }
+        }
+
+        public ObservableCollection<Brush> Palette { get; } = new() { Brushes.Blue, Brushes.Green, Brushes.Red, Brushes.Purple };
+        private Brush selectedColor;
+        public Brush SelectedColor
+        {
+            get => selectedColor;
+            set
+            {
+                if (selectedColor != value)
+                {
+                    selectedColor = value;
+                    OnPropertyChanged(nameof(SelectedColor));
+                }
+            }
+        }
+
+        public ObservableCollection<string> Fonts { get; } = new() { "Arial", "Segoe UI", "Times New Roman" };
+        private string selectedFont;
+        public string SelectedFont
+        {
+            get => selectedFont;
+            set
+            {
+                if (selectedFont != value)
+                {
+                    selectedFont = value;
+                    OnPropertyChanged(nameof(SelectedFont));
+                }
+            }
+        }
+
+        public ObservableCollection<Brush> NeonColors { get; } = new() { Brushes.Cyan, Brushes.Magenta, Brushes.Lime };
+        private Brush selectedNeonColor;
+        public Brush SelectedNeonColor
+        {
+            get => selectedNeonColor;
+            set
+            {
+                if (selectedNeonColor != value)
+                {
+                    selectedNeonColor = value;
+                    OnPropertyChanged(nameof(SelectedNeonColor));
+                }
+            }
+        }
+
+        private bool neonEnabled;
+        public bool NeonEnabled
+        {
+            get => neonEnabled;
+            set
+            {
+                if (neonEnabled != value)
+                {
+                    neonEnabled = value;
+                    OnPropertyChanged(nameof(NeonEnabled));
+                }
+            }
+        }
+
+        private double neonIntensity = 0.5;
+        public double NeonIntensity
+        {
+            get => neonIntensity;
+            set
+            {
+                if (neonIntensity != value)
+                {
+                    neonIntensity = value;
+                    OnPropertyChanged(nameof(NeonIntensity));
+                }
+            }
+        }
+
+        public ObservableCollection<PriorityFilter> PriorityFilters => calendar.Filters;
+        public PriorityFilter SelectedPriorityFilter
+        {
+            get => calendar.SelectedFilter;
+            set
+            {
+                if (calendar.SelectedFilter != value)
+                {
+                    calendar.SelectedFilter = value;
+                    OnPropertyChanged(nameof(SelectedPriorityFilter));
+                }
+            }
+        }
+
+        private double panelScale = 1.0;
+        public double PanelScale
+        {
+            get => panelScale;
+            set
+            {
+                if (panelScale != value)
+                {
+                    panelScale = value;
+                    OnPropertyChanged(nameof(PanelScale));
+                }
+            }
+        }
+
+        public SettingsViewModel(MainCalendarViewModel calendar)
+        {
+            this.calendar = calendar;
+            SelectedTheme = Themes[0];
+            selectedColor = Palette[0];
+            selectedFont = Fonts[0];
+            selectedNeonColor = NeonColors[0];
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/src/Views/SettingsPanel.xaml
+++ b/src/Views/SettingsPanel.xaml
@@ -1,0 +1,45 @@
+<UserControl x:Class="CalendarApp.Views.SettingsPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <ScrollViewer>
+        <StackPanel Margin="10">
+            <TextBlock Text="Theme" FontWeight="Bold"/>
+            <ComboBox Width="150" ItemsSource="{Binding Themes}" SelectedItem="{Binding SelectedTheme}"/>
+
+            <TextBlock Text="Palette" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ComboBox Width="150" ItemsSource="{Binding Palette}" SelectedItem="{Binding SelectedColor}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <Border Width="16" Height="16" Background="{Binding}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+
+            <TextBlock Text="Font" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ComboBox Width="150" ItemsSource="{Binding Fonts}" SelectedItem="{Binding SelectedFont}"/>
+
+            <CheckBox Content="Neon enabled" IsChecked="{Binding NeonEnabled}" Margin="0,10,0,0"/>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,5,0,0">
+                <TextBlock Text="Neon intensity" VerticalAlignment="Center"/>
+                <Slider Width="120" Margin="5,0,0,0" Minimum="0" Maximum="1" Value="{Binding NeonIntensity}"/>
+            </StackPanel>
+            <TextBlock Text="Neon color" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ComboBox Width="150" ItemsSource="{Binding NeonColors}" SelectedItem="{Binding SelectedNeonColor}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <Border Width="16" Height="16" Background="{Binding}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+
+            <TextBlock Text="Priority filter" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ComboBox Width="150" ItemsSource="{Binding PriorityFilters}" SelectedItem="{Binding SelectedPriorityFilter}"/>
+
+            <TextBlock Text="Panel scale" FontWeight="Bold" Margin="0,10,0,0"/>
+            <Slider Width="150" Minimum="0.5" Maximum="2" Value="{Binding PanelScale}"/>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>


### PR DESCRIPTION
## Summary
- add SettingsPanel view with controls for theme, palette, font and neon highlight options
- implement SettingsViewModel exposing theme, palette, fonts, neon parameters, priority filters and panel scaling

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adda963d6083328c5edb224b4b1765