### PR TITLE
feat: persist panel data

### DIFF
--- a/webnovel_app_v0_1/webnovel_app_v0_1/app/storage.py
+++ b/webnovel_app_v0_1/webnovel_app_v0_1/app/storage.py
@@ -1,8 +1,16 @@
 import json
 from pathlib import Path
+from typing import Union, Any
+
 
 class Storage:
-    def __init__(self, base_dir: Path):
+    """Helper around a directory used for persisting JSON files."""
+
+    def __init__(self, base_dir: Union[Path, str]):
+        self.set_base_dir(base_dir)
+
+    def set_base_dir(self, base_dir: Union[Path, str]):
+        """Change the base directory where files are stored."""
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
@@ -11,9 +19,12 @@ class Storage:
         p.parent.mkdir(parents=True, exist_ok=True)
         return p
 
-    def save_json(self, rel_path: str, data: dict):
+    def save_json(self, rel_path: str, data: Any):
         p = self.path(rel_path)
-        p.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        p.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
 
     def load_json(self, rel_path: str, default=None):
         p = self.path(rel_path)


### PR DESCRIPTION
## Summary
- add configurable Storage with dynamic base directory
- save and load panel data under year folders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adecaf2f40833293e6a553a36550ea