### PR TITLE
Reduce QDockWidget title padding

### DIFF
--- a/app/styles.py
+++ b/app/styles.py
@@ -20,6 +20,11 @@ def base_stylesheet(accent: str = "#00E5FF", neon_size: int = 8, neon_intensity:
         border: 1px solid #2A2D2E;
         border-radius: 10px;
     }}
+    QDockWidget::title {
+        padding: 2px;
+        margin: 0;
+    }
+
     QHeaderView::section {{
         background-color: #2A2D2E;
         color: #D0D0D0;


### PR DESCRIPTION
## Summary
- Tighten QDockWidget title area by setting minimal padding and margin in the base stylesheet

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae09ac53b883328ae8df0e85714f84