### PR TITLE
Move theme switch to settings dialog

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import (
     QComboBox,
 )
 
-from .styles import base_stylesheet, apply_glass_effect
+from .styles import base_stylesheet, light_stylesheet, apply_glass_effect
 from .settings_dialog import SettingsDialog
 from .version import get_version
 from .central.calendar_panel import CalendarPanel
@@ -156,22 +156,6 @@ class MainWindow(QMainWindow):
 
         tb.addSeparator()
 
-        theme_group = QActionGroup(self)
-        self.theme_actions = {}
-        act_dark = QAction("Тёмная", self, checkable=True)
-        act_dark.triggered.connect(lambda: self.set_theme("dark"))
-        theme_group.addAction(act_dark)
-        tb.addAction(act_dark)
-        self.theme_actions["dark"] = act_dark
-
-        act_light = QAction("Светлая", self, checkable=True)
-        act_light.triggered.connect(lambda: self.set_theme("light"))
-        theme_group.addAction(act_light)
-        tb.addAction(act_light)
-        self.theme_actions["light"] = act_light
-
-        tb.addSeparator()
-
         self.palette_combo = QComboBox()
         self.palette_combo.addItem("Циан", "cyan")
         self.palette_combo.addItem("Оранж", "orange")
@@ -264,8 +248,11 @@ class MainWindow(QMainWindow):
                 neon_intensity=self.prefs["neon_intensity"]
             ))
         else:
-            # For light theme use default palette and no stylesheet
-            self.setStyleSheet("")
+            self.setStyleSheet(light_stylesheet(
+                accent=self.prefs["accent"],
+                neon_size=self.prefs["neon_size"],
+                neon_intensity=self.prefs["neon_intensity"]
+            ))
             self.setPalette(self.style().standardPalette())
 
         # Glass
@@ -289,11 +276,6 @@ class MainWindow(QMainWindow):
         for pf, act in getattr(self, "priority_actions", {}).items():
             act.blockSignals(True)
             act.setChecked(pf == filt)
-            act.blockSignals(False)
-        # Theme actions state
-        for name, act in getattr(self, "theme_actions", {}).items():
-            act.blockSignals(True)
-            act.setChecked(name == self.prefs.get("theme"))
             act.blockSignals(False)
         # Palette combo state
         if hasattr(self, "palette_combo"):

--- a/app/settings_dialog.py
+++ b/app/settings_dialog.py
@@ -1,7 +1,7 @@
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox, QPushButton,
-    QColorDialog, QSlider, QFileDialog, QCheckBox, QSpinBox, QTabWidget, QWidget, QFormLayout, QLineEdit
+    QColorDialog, QSlider, QFileDialog, QCheckBox, QSpinBox, QTabWidget, QWidget, QFormLayout, QLineEdit, QRadioButton
 )
 
 from .priority_service import PriorityFilter
@@ -23,9 +23,18 @@ class SettingsDialog(QDialog):
         # Theme tab
         theme_tab = QWidget()
         fl = QFormLayout(theme_tab)
-        self.theme_combo = QComboBox()
-        self.theme_combo.addItems(["Ночная (тёмная)", "Дневная (светлая)"])
-        self.theme_combo.setCurrentIndex(0 if current.get("theme","dark")=="dark" else 1)
+        theme_box = QWidget()
+        thl = QHBoxLayout(theme_box)
+        thl.setContentsMargins(0, 0, 0, 0)
+        self.dark_radio = QRadioButton("Тёмная")
+        self.light_radio = QRadioButton("Светлая")
+        if current.get("theme", "dark") == "dark":
+            self.dark_radio.setChecked(True)
+        else:
+            self.light_radio.setChecked(True)
+        thl.addWidget(self.dark_radio)
+        thl.addWidget(self.light_radio)
+        fl.addRow("Тема", theme_box)
 
         # Palette / accent
         self.palette_combo = QComboBox()
@@ -45,7 +54,6 @@ class SettingsDialog(QDialog):
         self.texture_slider = QSlider(Qt.Horizontal); self.texture_slider.setRange(0, 10); self.texture_slider.setValue(current.get("glass_texture", 2))
         self.sharp_slider = QSlider(Qt.Horizontal); self.sharp_slider.setRange(0, 10); self.sharp_slider.setValue(current.get("glass_sharpness", 5))
 
-        fl.addRow("Тема", self.theme_combo)
         fl.addRow("Палитра", self.palette_combo)
         fl.addRow("Акцент", self.accent_btn)
         fl.addRow(self.glass_chk)
@@ -160,7 +168,7 @@ class SettingsDialog(QDialog):
 
     def apply(self):
         res = SettingsResult(
-            theme = "dark" if self.theme_combo.currentIndex()==0 else "light",
+            theme = "dark" if self.dark_radio.isChecked() else "light",
             accent = self._accent,
             palette = self.palette_combo.currentData(),
             glass_enabled = self.glass_chk.isChecked(),

--- a/app/styles.py
+++ b/app/styles.py
@@ -62,6 +62,67 @@ def base_stylesheet(accent: str = "#00E5FF", neon_size: int = 8, neon_intensity:
     }}
     """
 
+
+def light_stylesheet(accent: str = "#000000", neon_size: int = 8, neon_intensity: int = 60):
+    """Return a simple light stylesheet with white backgrounds and black text."""
+    return f"""
+    * {{
+        font-size: 13px;
+    }}
+    QWidget {{
+        background-color: #FFFFFF;
+        color: #000000;
+    }}
+    QMainWindow {{
+        background-color: #FFFFFF;
+    }}
+    QDockWidget, QFrame, QGroupBox, QTableView, QTableWidget, QListView, QTreeView {{
+        background-color: #F5F5F5;
+        border: 1px solid #C0C0C0;
+        border-radius: 10px;
+    }}
+    QDockWidget::title {
+        padding: 2px;
+        margin: 0;
+    }
+
+    QHeaderView::section {{
+        background-color: #E0E0E0;
+        color: #202020;
+        border: none;
+        padding: 6px;
+    }}
+    QPushButton {{
+        background-color: #E8E8E8;
+        border: 1px solid #C0C0C0;
+        border-radius: 10px;
+        padding: 8px 12px;
+    }}
+    QPushButton:hover {{
+        border-color: {accent};
+    }}
+    QPushButton:pressed {{
+        background-color: #D0D0D0;
+    }}
+    QToolBar, QMenuBar {{
+        background-color: #F0F0F0;
+        border: none;
+    }}
+    QStatusBar {{
+        background-color: #F0F0F0;
+        border-top: 1px solid #C0C0C0;
+    }}
+    QLineEdit, QSpinBox, QComboBox, QTextEdit, QPlainTextEdit {{
+        background-color: #FFFFFF;
+        border: 1px solid #C0C0C0;
+        border-radius: 8px;
+        padding: 6px 8px;
+    }}
+    QLineEdit:focus, QSpinBox:focus, QComboBox:focus, QTextEdit:focus, QPlainTextEdit:focus {{
+        border: 1px solid {accent};
+    }}
+    """
+    
 def apply_glass_effect(window, enabled: bool, opacity: float = 0.9):
     '''Placeholder glass effect: adjust window opacity. Real acrylic blur can be added later for Windows via DWM.'''
     if enabled:


### PR DESCRIPTION
## Summary
- Drop dark/light actions from the main toolbar and pick theme inside the settings dialog instead.
- Add `light_stylesheet` for white-background, dark-text UI.
- Apply the light stylesheet when the light theme is chosen.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae0db4450c8332929721d5a3b21561