### PR TITLE
Remove save directory action from toolbar

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -7,7 +7,6 @@ from PySide6.QtWidgets import (
     QDockWidget,
     QLabel,
     QStatusBar,
-    QFileDialog,
     QWidget,
     QHBoxLayout,
     QComboBox,
@@ -137,10 +136,6 @@ class MainWindow(QMainWindow):
         act_settings.triggered.connect(self.open_settings)
         tb.addAction(act_settings)
 
-        act_save_dir = QAction("Папка сохранения", self)
-        act_save_dir.triggered.connect(self.pick_save_dir)
-        tb.addAction(act_save_dir)
-
         tb.addSeparator()
 
         group = QActionGroup(self)
@@ -198,12 +193,6 @@ class MainWindow(QMainWindow):
             lambda vis: self.act_show_bottom.setEnabled(not vis)
         )
         self.act_show_bottom.setEnabled(not self.bottom_dock.isVisible())
-
-    def pick_save_dir(self):
-        d = QFileDialog.getExistingDirectory(self, "Выбрать папку сохранения")
-        if d:
-            self.prefs["save_dir"] = d
-            self.settings.setValue("save_dir", d)
 
     def set_priority_filter(self, filt: PriorityFilter):
         self.prefs["priority_filter"] = int(filt)


### PR DESCRIPTION
## Summary
- remove outdated "save directory" toolbar action
- drop unused `pick_save_dir` helper and QFileDialog import

## Testing
- `python -m py_compile app/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae1110f9b4833282378c2eea91ae35