### PR TITLE
fix: escape QDockWidget title selector braces

### DIFF
--- a/app/styles.py
+++ b/app/styles.py
@@ -61,10 +61,10 @@ def base_stylesheet(accent: str = "#00E5FF", neon_size: int = 8, neon_intensity:
         border: 1px solid #2A2D2E;
         border-radius: 10px;
     }}
-    QDockWidget::title {
+    QDockWidget::title {{
         padding: 2px;
         margin: 0;
-    }
+    }}
 
     QHeaderView::section {{
         background-color: #2A2D2E;


### PR DESCRIPTION
## Summary
- escape QDockWidget title selector braces in base stylesheet
- ensure remaining CSS blocks in base stylesheet use double braces

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1aedf86c83328841db3f8f767563