### PR TITLE
Add scale handling to stats panel

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -270,6 +270,7 @@ class MainWindow(QMainWindow):
         self.central.set_scale(scale)
         self.left_panel.set_scale(scale)
         self.right_panel.set_scale(scale)
+        self.stats_panel.set_scale(scale)
         self.central.set_scale_edit_mode(self.prefs.get("scale_edit_mode", False))
         # Panel edit modes
         self.left_panel.set_edit_mode(self.prefs.get("left_edit_mode", False))

--- a/app/panels/stats_panel.py
+++ b/app/panels/stats_panel.py
@@ -78,6 +78,7 @@ class StatsPanel(QWidget):
         self.storage = storage or Storage(Path("data"))
         self.current_year = 0
         self.current_month = 0
+        self.scale_percent = 100
 
         lay = QVBoxLayout(self)
         lay.addWidget(QLabel("Результаты / Статистика"))
@@ -130,6 +131,17 @@ class StatsPanel(QWidget):
             charts_lay.addWidget(ce)
             self.chart_sections[name] = ce
         charts_lay.addStretch()
+
+    # ------------------------------------------------------------------
+    def set_scale(self, percent: int):
+        self.scale_percent = max(50, min(200, percent))
+        f = self.font()
+        f.setPointSize(int(12 * self.scale_percent / 100))
+        self.setFont(f)
+        for r in range(self.metrics_table.rowCount()):
+            self.metrics_table.setRowHeight(r, int(24 * self.scale_percent / 100))
+        for r in range(self.software_table.rowCount()):
+            self.software_table.setRowHeight(r, int(24 * self.scale_percent / 100))
 
     # ------------------------------------------------------------------
     def set_month(self, year: int, month: int):
@@ -190,6 +202,8 @@ class StatsPanel(QWidget):
         for name, section in self.chart_sections.items():
             values = [int(d.get("metrics", {}).get(name, 0) or 0) for d in monthly_data]
             section.set_series(values)
+
+        self.set_scale(self.scale_percent)
 
     # ------------------------------------------------------------------
     def toggle_charts(self):


### PR DESCRIPTION
## Summary
- add scaling support for stats panel fonts and row heights
- apply stats panel scaling from main window preferences

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae2199cd8883328fb0ac88d56b69b9