### PR TITLE
feat: add top month form and persistence

### DIFF
--- a/app/top_aggregator.py
+++ b/app/top_aggregator.py
@@ -53,6 +53,9 @@ class TopAggregator:
         raw = self.storage.load_json(f"{year}/top_month_{month:02d}.json", {}) or {}
         result: Dict[str, Stats] = {}
         if isinstance(raw, dict):
+            # new format may store meta information under special key
+            if "__form__" in raw:
+                raw = {k: v for k, v in raw.items() if k != "__form__"}
             for name, info in raw.items():
                 result[name] = Stats(
                     plan=_to_int(info.get("plan")),


### PR DESCRIPTION
## Summary
- add data entry form for monthly top metrics
- persist form values alongside table data
- ignore form metadata during top aggregation

## Testing
- `python -m py_compile app/panels/top_month_panel.py app/top_aggregator.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae95bb81f083329af15958c4d4fc27