### PR TITLE
Use settings dialog for priority filtering

### DIFF
--- a/app/settings_dialog.py
+++ b/app/settings_dialog.py
@@ -192,7 +192,7 @@ class SettingsDialog(QDialog):
             central_scale = self.central_scale.value(),
             left_edit_mode = self.left_panel_edit.isChecked(),
             right_edit_mode = self.right_panel_edit.isChecked(),
-            priority_filter = int(self.priority_combo.currentData()),
+            priority_filter = self.priority_combo.currentData(),
         )
         self.settings_applied.emit(res)
         self.accept()


### PR DESCRIPTION
## Summary
- Remove toolbar actions and action group for priority filters
- Apply priority filter from settings dialog combo via `set_priority_filter`
- Simplify preferences application by dropping `priority_actions` handling

## Testing
- `python -m py_compile app/main_window.py app/settings_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae971861788332b818b0a82283b6b7