### PR TITLE
Remove dock titles and toolbar, add overlay toggle buttons

### DIFF
--- a/app/icons/menu_vertical.svg
+++ b/app/icons/menu_vertical.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="4" height="18" fill="currentColor"/>
+  <rect x="10" y="3" width="4" height="18" fill="currentColor"/>
+  <rect x="17" y="3" width="4" height="18" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## Summary
- Hide dock title bars and disable dock features for side panels
- Drop the old toolbar and introduce overlay buttons to toggle docks
- Add custom three-bar SVG icon used by new toggle buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae9e0fa1708332a0eb7ad2ac3bacde