### PR TITLE
feat: access priority log from settings dialog

### DIFF
--- a/app/settings_dialog.py
+++ b/app/settings_dialog.py
@@ -71,6 +71,10 @@ class SettingsDialog(QDialog):
         self.priority_combo.addItem("1-2", PriorityFilter.OneToTwo)
         fl.addRow("Фильтр приоритетов", self.priority_combo)
 
+        self.log_btn = QPushButton("Открыть журнал приоритетов")
+        self.log_btn.clicked.connect(parent.open_priority_log)
+        fl.addRow(self.log_btn)
+
         # Fonts tab
         fonts_tab = QWidget()
         ffl = QFormLayout(fonts_tab)


### PR DESCRIPTION
## Summary
- add "Open priority log" button to settings dialog
- ensure priority filter is only adjustable via settings dropdown

## Testing
- `python -m py_compile app/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae9f180158833283c5df284950f0a2