### PR TITLE
Add editable main panel and drop priority log

### DIFF
--- a/app/central/main_panel.py
+++ b/app/central/main_panel.py
@@ -1,0 +1,244 @@
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QSpinBox,
+    QComboBox,
+    QPushButton,
+    QInputDialog,
+    QMenu,
+)
+
+from ..storage import Storage
+from ..priority_service import PriorityFilter, sort_tasks, filter_tasks, color_for
+
+
+@dataclass
+class Work:
+    name: str
+    plan: int = 0
+    done: int = 0
+    priority: int = 1
+    is_adult: bool = False
+    comment: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(data: dict) -> "Work":
+        return Work(
+            name=data.get("name", ""),
+            plan=int(data.get("plan", 0)),
+            done=int(data.get("done", 0)),
+            priority=int(data.get("priority", 1)),
+            is_adult=bool(data.get("is_adult", False)),
+            comment=data.get("comment", ""),
+        )
+
+
+class MainPanel(QWidget):
+    """Simplified central panel showing a list of works per day."""
+
+    HEADERS = ["День", "Работа", "План", "Готово", "Приоритет", "18+", "Комментарий"]
+
+    def __init__(self, parent=None, storage: Storage | None = None):
+        super().__init__(parent)
+        self.storage = storage or Storage(Path("data"))
+        self.month_data: dict[int, list[Work]] = {}
+        self._row_map: dict[int, tuple[int, Work]] = {}
+        self.priority_filter = PriorityFilter.OneToFour
+        self.scale_percent = 100
+
+        lay = QVBoxLayout(self)
+        ctrl = QHBoxLayout()
+        self.year = QSpinBox(self)
+        self.year.setRange(2000, 2100)
+        self.month = QComboBox(self)
+        self.month.addItems(["Янв","Фев","Мар","Апр","Май","Июн","Июл","Авг","Сен","Окт","Ноя","Дек"])
+        ctrl.addWidget(QLabel("Год"))
+        ctrl.addWidget(self.year)
+        ctrl.addSpacing(12)
+        ctrl.addWidget(QLabel("Месяц"))
+        ctrl.addWidget(self.month)
+        ctrl.addStretch(1)
+        self.add_btn = QPushButton("Добавить работу", self)
+        ctrl.addWidget(self.add_btn)
+        lay.addLayout(ctrl)
+
+        self.table = QTableWidget(0, len(self.HEADERS), self)
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+        self.table.setEditTriggers(QTableWidget.DoubleClicked | QTableWidget.SelectedClicked | QTableWidget.EditKeyPressed)
+        self.table.itemChanged.connect(self._on_item_changed)
+        self.table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.table.customContextMenuRequested.connect(self._show_menu)
+        lay.addWidget(self.table)
+
+        self.add_btn.clicked.connect(self.add_work)
+        self.year.valueChanged.connect(self.rebuild)
+        self.month.currentIndexChanged.connect(self.rebuild)
+
+        self.year.setValue(self.year.value())  # trigger default
+        self.rebuild()
+
+    # ------------------------------------------------------------------
+    def set_scale(self, percent: int):
+        self.scale_percent = max(50, min(200, percent))
+        f = self.font()
+        f.setPointSize(int(12 * self.scale_percent / 100))
+        self.setFont(f)
+        for r in range(self.table.rowCount()):
+            self.table.setRowHeight(r, int(24 * self.scale_percent / 100))
+
+    def set_scale_edit_mode(self, enabled: bool):
+        trigger = (QTableWidget.DoubleClicked | QTableWidget.SelectedClicked | QTableWidget.EditKeyPressed) if enabled else QTableWidget.NoEditTriggers
+        self.table.setEditTriggers(trigger)
+
+    def set_priority_filter(self, filt: PriorityFilter):
+        self.priority_filter = filt
+        self._refresh_table()
+
+    # ------------------------------------------------------------------
+    def rebuild(self):
+        y = self.year.value()
+        m = self.month.currentIndex() + 1
+        self.load_month(y, m)
+        self._refresh_table()
+
+    def _refresh_table(self):
+        self.table.blockSignals(True)
+        rows = sum(
+            len(list(filter_tasks(v, self.priority_filter)))
+            for v in self.month_data.values()
+        )
+        self.table.setRowCount(rows)
+        self._row_map.clear()
+        row = 0
+        for day in sorted(self.month_data.keys()):
+            works = list(filter_tasks(self.month_data[day], self.priority_filter))
+            for work in sort_tasks(works):
+                self._row_map[row] = (day, work)
+                self._set_row(row, day, work)
+                row += 1
+        self.table.blockSignals(False)
+        self.set_scale(self.scale_percent)
+
+    def _set_row(self, row: int, day: int, work: Work):
+        def set_item(col: int, text: str, checkable: bool = False, checked: bool = False):
+            item = QTableWidgetItem(text)
+            if checkable:
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+                item.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+                item.setText("")
+            self.table.setItem(row, col, item)
+        set_item(0, str(day))
+        set_item(1, work.name)
+        set_item(2, str(work.plan))
+        set_item(3, str(work.done))
+        pri_item = QTableWidgetItem(str(work.priority))
+        pri_item.setForeground(QColor(color_for(work.priority)))
+        self.table.setItem(row, 4, pri_item)
+        set_item(5, "", checkable=True, checked=work.is_adult)
+        set_item(6, work.comment)
+
+    # ------------------------------------------------------------------
+    def _on_item_changed(self, item: QTableWidgetItem):
+        row = item.row()
+        col = item.column()
+        if row not in self._row_map:
+            return
+        day, work = self._row_map[row]
+        try:
+            if col == 0:
+                new_day = int(item.text())
+                if new_day != day:
+                    self.month_data[day].remove(work)
+                    self.month_data.setdefault(new_day, []).append(work)
+                    if not self.month_data[day]:
+                        del self.month_data[day]
+                    self._refresh_table()
+                    self.save_month()
+                    return
+            elif col == 1:
+                work.name = item.text()
+            elif col == 2:
+                work.plan = int(item.text() or 0)
+            elif col == 3:
+                work.done = int(item.text() or 0)
+            elif col == 4:
+                work.priority = int(item.text() or 1)
+            elif col == 5:
+                work.is_adult = item.checkState() == Qt.Checked
+            elif col == 6:
+                work.comment = item.text()
+        except ValueError:
+            pass
+        self.save_month()
+
+    def _show_menu(self, pos):
+        row = self.table.rowAt(pos.y())
+        if row < 0 or row not in self._row_map:
+            return
+        menu = QMenu(self)
+        act_del = menu.addAction("Удалить")
+        action = menu.exec(self.table.viewport().mapToGlobal(pos))
+        if action == act_del:
+            day, work = self._row_map[row]
+            self.month_data[day].remove(work)
+            if not self.month_data[day]:
+                del self.month_data[day]
+            self.save_month()
+            self._refresh_table()
+
+    # ------------------------------------------------------------------
+    def add_work(self):
+        day, ok = QInputDialog.getInt(self, "День", "День", 1, 1, 31)
+        if not ok:
+            return
+        name, ok = QInputDialog.getText(self, "Работа", "Работа")
+        if not ok or not name:
+            return
+        plan, ok = QInputDialog.getInt(self, "План", "План", 0, 0, 9999)
+        if not ok:
+            return
+        done, ok = QInputDialog.getInt(self, "Готово", "Готово", 0, 0, 9999)
+        if not ok:
+            return
+        priority, ok = QInputDialog.getInt(self, "Приоритет", "Приоритет (1-4)", 1, 1, 4)
+        if not ok:
+            return
+        adult, ok = QInputDialog.getItem(self, "Категория", "Категория", ["0+", "18+"], 0)
+        if not ok:
+            return
+        comment, ok = QInputDialog.getText(self, "Комментарий", "Комментарий")
+        if not ok:
+            return
+        w = Work(name=name, plan=plan, done=done, priority=priority, is_adult=(adult == "18+"), comment=comment)
+        self.month_data.setdefault(day, []).append(w)
+        self.save_month()
+        self._refresh_table()
+
+    # ------------------------------------------------------------------
+    def load_month(self, year: int, month: int):
+        data = self.storage.load_json(f"{year}/{month:02d}.json", {}) or {}
+        self.month_data = {
+            int(d): [Work.from_dict(w) for w in wl]
+            for d, wl in data.items()
+        }
+
+    def save_month(self):
+        y = self.year.value()
+        m = self.month.currentIndex() + 1
+        data = {
+            str(day): [w.to_dict() for w in works]
+            for day, works in self.month_data.items() if works
+        }
+        self.storage.save_json(f"{y}/{m:02d}.json", data)

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -8,48 +8,20 @@ from PySide6.QtWidgets import (
     QLabel,
     QStatusBar,
     QWidget,
-    QVBoxLayout,
-    QDialog,
-    QTextEdit,
-    QPushButton,
     QToolButton,
 )
 
 from .styles import base_stylesheet, light_stylesheet, apply_glass_effect
 from .settings_dialog import SettingsDialog
 from .version import get_version
-from .central.calendar_panel import CalendarPanel
+from .central.main_panel import MainPanel
 from .panels.top_month_panel import TopMonthPanel
 from .panels.postings_panel import PostingsPanel
 from .panels.stats_panel import StatsPanel
 from .storage import Storage
-from .priority_service import (
-    PriorityFilter,
-    LOG_FILE,
-)
+from .priority_service import PriorityFilter
 
 
-
-class PriorityLogDialog(QDialog):
-    def __init__(self, log_path: Path, parent=None):
-        super().__init__(parent)
-        self.setWindowTitle("Журнал изменений приоритетов")
-        self.resize(500, 400)
-        layout = QVBoxLayout(self)
-        self.text = QTextEdit(self)
-        self.text.setReadOnly(True)
-        layout.addWidget(self.text)
-        refresh_btn = QPushButton("Обновить", self)
-        refresh_btn.clicked.connect(self.refresh)
-        layout.addWidget(refresh_btn)
-        self.log_path = log_path
-        self.refresh()
-
-    def refresh(self):
-        if self.log_path.exists():
-            self.text.setPlainText(self.log_path.read_text(encoding="utf-8"))
-        else:
-            self.text.setPlainText("Журнал пуст.")
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -84,9 +56,7 @@ class MainWindow(QMainWindow):
         self.storage = Storage(Path(save_dir))
 
         # Central panel
-        self.central = CalendarPanel(self)
-        self.central.storage = self.storage
-        self.central.rebuild()
+        self.central = MainPanel(self, storage=self.storage)
         self.setCentralWidget(self.central)
 
         # Left dock (Top month)
@@ -231,10 +201,6 @@ class MainWindow(QMainWindow):
     def resizeEvent(self, e):
         super().resizeEvent(e)
         self._place_toggle_buttons()
-
-    def open_priority_log(self):
-        dlg = PriorityLogDialog(LOG_FILE, self)
-        dlg.exec()
 
     def set_priority_filter(self, filt: PriorityFilter):
         self.prefs["priority_filter"] = int(filt)

--- a/app/panels/top_month_panel.py
+++ b/app/panels/top_month_panel.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from ..storage import Storage
 
 if False:  # type checking only
-    from ..central.calendar_panel import CalendarPanel
+    from ..central.main_panel import MainPanel
 
 class TopMonthPanel(QWidget):
     """Panel showing monthly top works with editable statistics."""
@@ -169,14 +169,14 @@ class TopMonthPanel(QWidget):
         else:
             item.setFlags(flags & ~Qt.ItemIsEditable)
 
-    def load_month(self, calendar: "CalendarPanel", year: int, month: int):
-        """Load stats from CalendarPanel and stored data for given month."""
-        # ensure calendar data for the month is loaded
-        calendar.load_month(year, month)
+    def load_month(self, central: "MainPanel", year: int, month: int):
+        """Load stats from MainPanel and stored data for given month."""
+        # ensure central data for the month is loaded
+        central.load_month(year, month)
 
-        # aggregate works from calendar
+        # aggregate works from central
         stats: Dict[str, Dict[str, Any]] = {}
-        for works in calendar.month_data.values():
+        for works in central.month_data.values():
             for w in works:
                 info = stats.setdefault(w.name, {"plan": 0, "done": 0, "adult": False})
                 info["plan"] += w.plan

--- a/app/settings_dialog.py
+++ b/app/settings_dialog.py
@@ -71,10 +71,6 @@ class SettingsDialog(QDialog):
         self.priority_combo.addItem("1-2", PriorityFilter.OneToTwo)
         fl.addRow("Фильтр приоритетов", self.priority_combo)
 
-        self.log_btn = QPushButton("Открыть журнал приоритетов")
-        self.log_btn.clicked.connect(parent.open_priority_log)
-        fl.addRow(self.log_btn)
-
         # Fonts tab
         fonts_tab = QWidget()
         ffl = QFormLayout(fonts_tab)


### PR DESCRIPTION
## Summary
- add MainPanel with editable day/work table and storage-backed persistence
- swap CalendarPanel for MainPanel in main window and remove priority log UI
- adapt panels and settings dialog to work with the new central panel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae9fe17194833283baf784d420a4f0