### PR TITLE
Adjust dock toggle button placement and sizing

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -110,16 +110,22 @@ class MainWindow(QMainWindow):
         self.left_btn = QToolButton(self)
         self.left_btn.setIcon(icon)
         self.left_btn.setAutoRaise(True)
+        self.left_btn.setFixedSize(24, 24)
+        self.left_btn.setIconSize(QSize(24, 24))
         self.left_btn.clicked.connect(self.toggle_left_dock)
 
         self.right_btn = QToolButton(self)
         self.right_btn.setIcon(icon)
         self.right_btn.setAutoRaise(True)
+        self.right_btn.setFixedSize(24, 24)
+        self.right_btn.setIconSize(QSize(24, 24))
         self.right_btn.clicked.connect(self.toggle_right_dock)
 
         self.bottom_btn = QToolButton(self)
         self.bottom_btn.setIcon(icon)
         self.bottom_btn.setAutoRaise(True)
+        self.bottom_btn.setFixedSize(24, 24)
+        self.bottom_btn.setIconSize(QSize(24, 24))
         self.bottom_btn.clicked.connect(self.toggle_bottom_dock)
 
         settings_icon = QIcon.fromTheme(
@@ -129,7 +135,7 @@ class MainWindow(QMainWindow):
         self.settings_btn.setIcon(settings_icon)
         self.settings_btn.setAutoRaise(True)
         self.settings_btn.setFixedSize(24, 24)
-        self.settings_btn.setIconSize(QSize(16, 16))
+        self.settings_btn.setIconSize(QSize(24, 24))
         self.settings_btn.clicked.connect(self.open_settings)
 
         self.left_dock.visibilityChanged.connect(self._place_toggle_buttons)
@@ -197,18 +203,19 @@ class MainWindow(QMainWindow):
             self.bottom_dock.show()
 
     def _place_toggle_buttons(self, *args):
-        geo = self.centralWidget().geometry()
+        rect = self.rect()
         margin = 5
-        self.left_btn.move(geo.left() + margin, geo.top() + margin)
+        self.left_btn.move(rect.left() + margin, rect.top() + margin)
         self.right_btn.move(
-            geo.right() - self.right_btn.width() - margin, geo.top() + margin
+            rect.right() - self.right_btn.width() - margin, rect.top() + margin
         )
         self.bottom_btn.move(
-            geo.left() + margin, geo.bottom() - self.bottom_btn.height() - margin
+            rect.left() + margin,
+            rect.bottom() - self.bottom_btn.height() - margin,
         )
         self.settings_btn.move(
-            self.width() - self.settings_btn.width() - margin,
-            margin,
+            rect.right() - self.settings_btn.width() - margin,
+            rect.top() + margin,
         )
         for btn in (self.left_btn, self.right_btn, self.bottom_btn, self.settings_btn):
             btn.raise_()


### PR DESCRIPTION
## Summary
- Ensure all dock toggle buttons use 24px fixed and icon sizes
- Recalculate toggle button positions from the main window rect for top-left, top-right, and bottom-left docking controls
- Keep toggle buttons aligned during window resize events

## Testing
- `python -m py_compile app/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68aead7f7de883329f01c9b68f5981c1