### PR TITLE
feat: introduce daily grid panel

### DIFF
--- a/app/central/daily_grid_panel.py
+++ b/app/central/daily_grid_panel.py
@@ -1,0 +1,257 @@
+from dataclasses import dataclass, asdict
+from pathlib import Path
+import calendar
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QSpinBox,
+    QComboBox,
+)
+
+from ..storage import Storage
+from ..priority_service import PriorityFilter, filter_tasks, color_for
+
+
+@dataclass
+class Work:
+    name: str
+    plan: int = 0
+    done: int = 0
+    priority: int = 1
+    is_adult: bool = False
+    comment: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(data: dict) -> "Work":
+        return Work(
+            name=data.get("name", ""),
+            plan=int(data.get("plan", 0)),
+            done=int(data.get("done", 0)),
+            priority=int(data.get("priority", 1)),
+            is_adult=bool(data.get("is_adult", False)),
+            comment=data.get("comment", ""),
+        )
+
+
+class DayCell(QWidget):
+    """Widget representing a single day's list of works."""
+
+    changed = Signal()
+
+    HEADERS = ["Работа", "План", "Готово", "Приоритет", "18+", "Комментарий"]
+
+    def __init__(self, rows: int, parent: QWidget | None = None):
+        super().__init__(parent)
+        self.rows_per_day = rows
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        self.table = QTableWidget(rows, len(self.HEADERS), self)
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+        self.table.setEditTriggers(
+            QTableWidget.DoubleClicked
+            | QTableWidget.SelectedClicked
+            | QTableWidget.EditKeyPressed
+        )
+        lay.addWidget(self.table)
+        self._works: list[Work] = [Work("") for _ in range(rows)]
+        self.table.itemChanged.connect(self._on_item_changed)
+
+    # --------------------------------------------------------------
+    def set_works(self, works: list[Work], priority_filter: PriorityFilter):
+        filtered = list(filter_tasks(works, priority_filter))
+        self._works = filtered + [Work("") for _ in range(self.rows_per_day - len(filtered))]
+        self.table.blockSignals(True)
+        for row, work in enumerate(self._works):
+            self._set_row(row, work)
+        self.table.blockSignals(False)
+
+    def get_works(self) -> list[Work]:
+        return [w for w in self._works if w.name]
+
+    def _set_row(self, row: int, work: Work):
+        def set_item(col: int, text: str, checkable: bool = False, checked: bool = False):
+            item = QTableWidgetItem(text)
+            if checkable:
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+                item.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+                item.setText("")
+            self.table.setItem(row, col, item)
+
+        set_item(0, work.name)
+        set_item(1, str(work.plan))
+        set_item(2, str(work.done))
+        pri_item = QTableWidgetItem(str(work.priority))
+        pri_item.setForeground(QColor(color_for(work.priority)))
+        self.table.setItem(row, 3, pri_item)
+        set_item(4, "", checkable=True, checked=work.is_adult)
+        set_item(5, work.comment)
+
+    def _on_item_changed(self, item: QTableWidgetItem):
+        row = item.row()
+        col = item.column()
+        if row >= len(self._works):
+            return
+        work = self._works[row]
+        try:
+            if col == 0:
+                work.name = item.text()
+            elif col == 1:
+                work.plan = int(item.text() or 0)
+            elif col == 2:
+                work.done = int(item.text() or 0)
+            elif col == 3:
+                work.priority = int(item.text() or 1)
+            elif col == 4:
+                work.is_adult = item.checkState() == Qt.Checked
+            elif col == 5:
+                work.comment = item.text()
+        except ValueError:
+            pass
+        self.changed.emit()
+
+    # --------------------------------------------------------------
+    def set_scale(self, percent: int):
+        f = self.font()
+        f.setPointSize(int(12 * percent / 100))
+        self.table.setFont(f)
+        for r in range(self.table.rowCount()):
+            self.table.setRowHeight(r, int(24 * percent / 100))
+
+    def set_edit_mode(self, enabled: bool):
+        trigger = (
+            QTableWidget.DoubleClicked
+            | QTableWidget.SelectedClicked
+            | QTableWidget.EditKeyPressed
+            if enabled
+            else QTableWidget.NoEditTriggers
+        )
+        self.table.setEditTriggers(trigger)
+
+
+class DailyGridPanel(QWidget):
+    """Panel showing month data in grid form: columns are days (1-31), rows are weeks."""
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        storage: Storage | None = None,
+        rows_per_day: int = 6,
+    ):
+        super().__init__(parent)
+        self.storage = storage or Storage(Path("data"))
+        self.rows_per_day = rows_per_day
+        self.month_data: dict[int, list[Work]] = {}
+        self.priority_filter = PriorityFilter.OneToFour
+        self.scale_percent = 100
+        self.day_widgets: dict[int, DayCell] = {}
+
+        lay = QVBoxLayout(self)
+        ctrl = QHBoxLayout()
+        self.year = QSpinBox(self)
+        self.year.setRange(2000, 2100)
+        self.month = QComboBox(self)
+        self.month.addItems([
+            "Янв","Фев","Мар","Апр","Май","Июн",
+            "Июл","Авг","Сен","Окт","Ноя","Дек"
+        ])
+        ctrl.addWidget(QLabel("Год"))
+        ctrl.addWidget(self.year)
+        ctrl.addSpacing(12)
+        ctrl.addWidget(QLabel("Месяц"))
+        ctrl.addWidget(self.month)
+        ctrl.addStretch(1)
+        lay.addLayout(ctrl)
+
+        self.grid = None
+        self._build_grid()
+        lay.addWidget(self.grid)
+
+        self.year.valueChanged.connect(self.rebuild)
+        self.month.currentIndexChanged.connect(self.rebuild)
+        self.rebuild()
+
+    # --------------------------------------------------------------
+    def _build_grid(self):
+        if self.grid is not None:
+            self.grid.deleteLater()
+            self.day_widgets.clear()
+        self.grid = QTableWidget(6, 31, self)
+        self.grid.setHorizontalHeaderLabels([str(i) for i in range(1, 32)])
+        self.grid.setVerticalHeaderLabels([str(i) for i in range(1, 7)])
+        for day in range(1, 32):
+            row = (day - 1) // 7
+            col = day - 1
+            cell = DayCell(self.rows_per_day, self.grid)
+            cell.changed.connect(self.save_month)
+            self.grid.setCellWidget(row, col, cell)
+            self.day_widgets[day] = cell
+
+    # --------------------------------------------------------------
+    def set_rows_per_day(self, rows: int):
+        if rows == self.rows_per_day:
+            return
+        self.rows_per_day = rows
+        self._build_grid()
+        self.rebuild()
+
+    def set_scale(self, percent: int):
+        self.scale_percent = max(50, min(200, percent))
+        f = self.font()
+        f.setPointSize(int(12 * self.scale_percent / 100))
+        self.setFont(f)
+        for cell in self.day_widgets.values():
+            cell.set_scale(self.scale_percent)
+        for r in range(self.grid.rowCount()):
+            self.grid.setRowHeight(r, int(self.rows_per_day * 24 * self.scale_percent / 100))
+
+    def set_scale_edit_mode(self, enabled: bool):
+        for cell in self.day_widgets.values():
+            cell.set_edit_mode(enabled)
+
+    def set_priority_filter(self, filt: PriorityFilter):
+        self.priority_filter = filt
+        self.rebuild()
+
+    # --------------------------------------------------------------
+    def rebuild(self):
+        y = self.year.value()
+        m = self.month.currentIndex() + 1
+        self.load_month(y, m)
+        days_in_month = calendar.monthrange(y, m)[1]
+        for day in range(1, 32):
+            w = self.day_widgets.get(day)
+            if not w:
+                continue
+            self.grid.setColumnHidden(day - 1, day > days_in_month)
+            works = self.month_data.get(day, []) if day <= days_in_month else []
+            w.set_works(works, self.priority_filter)
+        self.set_scale(self.scale_percent)
+
+    # --------------------------------------------------------------
+    def load_month(self, year: int, month: int):
+        data = self.storage.load_json(f"{year}/{month:02d}.json", {}) or {}
+        self.month_data = {
+            int(d): [Work.from_dict(w) for w in wl]
+            for d, wl in data.items()
+        }
+
+    def save_month(self):
+        y = self.year.value()
+        m = self.month.currentIndex() + 1
+        data = {}
+        for day, widget in self.day_widgets.items():
+            works = widget.get_works()
+            if works:
+                data[str(day)] = [w.to_dict() for w in works]
+        self.storage.save_json(f"{y}/{m:02d}.json", data)
+

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
 from .styles import base_stylesheet, light_stylesheet, apply_glass_effect
 from .settings_dialog import SettingsDialog
 from .version import get_version
-from .central.main_panel import MainPanel
+from .central.daily_grid_panel import DailyGridPanel
 from .panels.top_month_panel import TopMonthPanel
 from .panels.postings_panel import PostingsPanel
 from .panels.stats_panel import StatsPanel
@@ -50,6 +50,7 @@ class MainWindow(QMainWindow):
             "left_edit_mode": self.settings.value("left_edit_mode", False, type=bool),
             "right_edit_mode": self.settings.value("right_edit_mode", False, type=bool),
             "priority_filter": int(self.settings.value("priority_filter", PriorityFilter.OneToFour)),
+            "rows_per_day": int(self.settings.value("rows_per_day", 6)),
         }
 
         # Storage
@@ -57,7 +58,11 @@ class MainWindow(QMainWindow):
         self.storage = Storage(Path(save_dir))
 
         # Central panel
-        self.central = MainPanel(self, storage=self.storage)
+        self.central = DailyGridPanel(
+            self,
+            storage=self.storage,
+            rows_per_day=self.prefs.get("rows_per_day", 6),
+        )
         self.setCentralWidget(self.central)
 
         # Left dock (Top month)
@@ -296,6 +301,7 @@ class MainWindow(QMainWindow):
         self.left_panel.set_scale(scale)
         self.right_panel.set_scale(scale)
         self.stats_panel.set_scale(scale)
+        self.central.set_rows_per_day(self.prefs.get("rows_per_day", 6))
         self.central.set_scale_edit_mode(self.prefs.get("scale_edit_mode", False))
         # Panel edit modes
         self.left_panel.set_edit_mode(self.prefs.get("left_edit_mode", False))

--- a/app/panels/top_month_panel.py
+++ b/app/panels/top_month_panel.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from ..storage import Storage
 
 if False:  # type checking only
-    from ..central.main_panel import MainPanel
+    from ..central.daily_grid_panel import DailyGridPanel
 
 class TopMonthPanel(QWidget):
     """Panel showing monthly top works with editable statistics."""
@@ -169,7 +169,7 @@ class TopMonthPanel(QWidget):
         else:
             item.setFlags(flags & ~Qt.ItemIsEditable)
 
-    def load_month(self, central: "MainPanel", year: int, month: int):
+    def load_month(self, central: "DailyGridPanel", year: int, month: int):
         """Load stats from MainPanel and stored data for given month."""
         # ensure central data for the month is loaded
         central.load_month(year, month)

--- a/app/settings_dialog.py
+++ b/app/settings_dialog.py
@@ -106,12 +106,14 @@ class SettingsDialog(QDialog):
         self.scale_edit_mode = QCheckBox("Редактирование масштаба центральной области")
         self.scale_edit_mode.setChecked(current.get("scale_edit_mode", False))
         self.central_scale = QSpinBox(); self.central_scale.setRange(50, 200); self.central_scale.setValue(current.get("central_scale", 100))
+        self.rows_per_day = QSpinBox(); self.rows_per_day.setRange(1, 20); self.rows_per_day.setValue(current.get("rows_per_day", 6))
         self.left_panel_edit = QCheckBox("Редактирование левой панели (ТОП месяца)")
         self.left_panel_edit.setChecked(current.get("left_edit_mode", False))
         self.right_panel_edit = QCheckBox("Редактирование правой панели (постинг)")
         self.right_panel_edit.setChecked(current.get("right_edit_mode", False))
         scl.addRow(self.scale_edit_mode)
         scl.addRow("Масштаб центральной области (%)", self.central_scale)
+        scl.addRow("Строк на день", self.rows_per_day)
         scl.addRow(self.left_panel_edit)
         scl.addRow(self.right_panel_edit)
 
@@ -190,6 +192,7 @@ class SettingsDialog(QDialog):
             neon_intensity = self.neon_intensity.value(),
             scale_edit_mode = self.scale_edit_mode.isChecked(),
             central_scale = self.central_scale.value(),
+            rows_per_day = self.rows_per_day.value(),
             left_edit_mode = self.left_panel_edit.isChecked(),
             right_edit_mode = self.right_panel_edit.isChecked(),
             priority_filter = self.priority_combo.currentData(),


### PR DESCRIPTION
## Summary
- replace MainPanel with DailyGridPanel using day/weekly grid
- add rows_per_day setting to SettingsDialog and persist in QSettings
- wire MainWindow to new panel and configurable row counts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeae4cb9e48332994f210cff87e234