### PR TITLE
feat: add neon focus styles for panels

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -268,18 +268,30 @@ class MainWindow(QMainWindow):
     def apply_prefs(self):
         # Stylesheet / Theme
         if self.prefs.get("theme", "dark") == "dark":
-            self.setStyleSheet(base_stylesheet(
+            sheet = base_stylesheet(
                 accent=self.prefs["accent"],
                 neon_size=self.prefs["neon_size"],
-                neon_intensity=self.prefs["neon_intensity"]
-            ))
+                neon_intensity=self.prefs["neon_intensity"],
+            )
         else:
-            self.setStyleSheet(light_stylesheet(
+            sheet = light_stylesheet(
                 accent=self.prefs["accent"],
                 neon_size=self.prefs["neon_size"],
-                neon_intensity=self.prefs["neon_intensity"]
-            ))
+                neon_intensity=self.prefs["neon_intensity"],
+            )
             self.setPalette(self.style().standardPalette())
+        self.setStyleSheet(sheet)
+        # Re-polish panels so dock contents pick up the accent focus/hover styles
+        for w in (
+            self.central,
+            self.left_panel,
+            self.right_panel,
+            self.stats_panel,
+            self.left_dock,
+            self.right_dock,
+            self.bottom_dock,
+        ):
+            w.setStyleSheet("")
 
         # Glass
         apply_glass_effect(

--- a/app/styles.py
+++ b/app/styles.py
@@ -45,6 +45,8 @@ def base_stylesheet(accent: str = "#00E5FF", neon_size: int = 8, neon_intensity:
     '''Return a base dark stylesheet with rounded controls and a pseudo-neon focus.'''
     # Neon via shadow-like glow using box-shadow is not native in Qt stylesheets.
     # We emulate with focus ring and accent borders.
+    col = QColor(accent)
+    shadow = f"rgba({col.red()}, {col.green()}, {col.blue()}, {neon_intensity/100})"
     return f"""
     * {{
         font-size: 13px;
@@ -101,12 +103,24 @@ def base_stylesheet(accent: str = "#00E5FF", neon_size: int = 8, neon_intensity:
     }}
     QLineEdit:focus, QSpinBox:focus, QComboBox:focus, QTextEdit:focus, QPlainTextEdit:focus {{
         border: 1px solid {accent};
+        box-shadow: 0 0 {neon_size}px {shadow};
     }}
+    QDockWidget:focus, QFrame:focus, QGroupBox:focus, QTableView:focus,
+    QTableWidget:focus, QListView:focus, QTreeView:focus {
+        border: 1px solid {accent};
+        box-shadow: 0 0 {neon_size}px {shadow};
+    }
+    QDockWidget:hover, QFrame:hover, QGroupBox:hover, QTableView:hover,
+    QTableWidget:hover, QListView:hover, QTreeView:hover {
+        border-color: {accent};
+    }
     """
 
 
 def light_stylesheet(accent: str = "#000000", neon_size: int = 8, neon_intensity: int = 60):
     """Return a simple light stylesheet with white backgrounds and black text."""
+    col = QColor(accent)
+    shadow = f"rgba({col.red()}, {col.green()}, {col.blue()}, {neon_intensity/100})"
     return f"""
     * {{
         font-size: 13px;
@@ -163,7 +177,17 @@ def light_stylesheet(accent: str = "#000000", neon_size: int = 8, neon_intensity
     }}
     QLineEdit:focus, QSpinBox:focus, QComboBox:focus, QTextEdit:focus, QPlainTextEdit:focus {{
         border: 1px solid {accent};
+        box-shadow: 0 0 {neon_size}px {shadow};
     }}
+    QDockWidget:focus, QFrame:focus, QGroupBox:focus, QTableView:focus,
+    QTableWidget:focus, QListView:focus, QTreeView:focus {
+        border: 1px solid {accent};
+        box-shadow: 0 0 {neon_size}px {shadow};
+    }
+    QDockWidget:hover, QFrame:hover, QGroupBox:hover, QTableView:hover,
+    QTableWidget:hover, QListView:hover, QTreeView:hover {
+        border-color: {accent};
+    }
     """
     
 def apply_glass_effect(window, enabled: bool, opacity: float = 0.9,


### PR DESCRIPTION
## Summary
- extend dark and light styles with neon-accent focus/hover rules for dock and table widgets
- refresh panel styles in `apply_prefs` so docks and central widgets inherit the accent

## Testing
- `pytest`
- `python -m py_compile app/styles.py app/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeaffc1738833298f6e952f4194d6c